### PR TITLE
#1 開催日が過去のイベントを表示しないようにしました。

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -39,6 +39,7 @@ INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at=
 INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
 INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='ハッカソン', start_at='2022/09/06 23:58', end_at='2022/09/06 23:59';
 
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,8 @@
 <?php
 require('dbconnect.php');
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
+$today = date("Y-m-d");
+$stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '" . $today . "' GROUP BY events.id " );
 $events = $stmt->fetchAll();
 
 function get_day_of_week ($w) {


### PR DESCRIPTION
## 関連イシュー
#1

## 検証したこと
検証日：2022/9/8 
開催日が9/8より前の過去イベントが表示されていないことを確認しました。


## エビデンス
DBに入っているイベント一覧
<img width="1208" alt="Screen Shot 2022-09-08 at 11 40 59" src="https://user-images.githubusercontent.com/86845781/189021752-08afee40-30f2-405c-b06f-0c557bab9568.png">



イベントアプリの表示(9/8〜開催されるもののみ表示されている)
表示は上から開催日の近い順にイベントが並んでおり、一番近いのが2022-09-08のイベントになっているため、過去のイベントは表示されないようにできていることがわかる。

<img width="990" alt="Screen Shot 2022-09-08 at 11 34 59" src="https://user-images.githubusercontent.com/86845781/189021051-28010e8a-cb64-449d-b796-492259913f4c.png">



