### PR TITLE
#12 イベント参加管理 Issue1 誰が参加するかDBに保存する 

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -44,7 +44,7 @@ function get_day_of_week ($w) {
   <main class="bg-gray-100">
     <div class="w-full mx-auto p-5">
     <p class="ml-5 my-5" >ようこそ <?= $_SESSION['name'] ?> さん</p>
-      <!-- 
+      
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div class="flex">
@@ -54,7 +54,6 @@ function get_day_of_week ($w) {
           <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
         </div>
       </div>
-      -->
       <div id="events-list">
         <div class="flex justify-between items-center mb-3">
           <h2 class="text-sm font-bold">一覧</h2>
@@ -65,9 +64,16 @@ function get_day_of_week ($w) {
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
+          $event_id = $event['id'];
+          $stmt = $db->prepare("SELECT * FROM event_attendance LEFT JOIN events ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id where event_id = '$event_id'");
+          $stmt->execute();
+          $events_users = $stmt->fetchAll();
           ?>
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
+              <?php foreach ($events_users as $event_user) : ?>
+                <p><?= $event_user['name']; ?></p>
+              <?php endforeach; ?>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
               <p class="text-xs text-gray-600">


### PR DESCRIPTION
## 関連イシュー
#12 

## 検証したこと
イベントの参加ボタンを押すとdbのevent_attendanceテーブルに選択したeventのidとログインしているユーザーのidをinsertしてdbに保存している
dbからどのイベントに誰ガッ参加するか確認可能

- [x] DBの情報から誰が参加する予定か確認可能

## エビデンス
前のdb情報
<img width="1470" alt="スクリーンショット 2022-09-08 14 50 37" src="https://user-images.githubusercontent.com/94046278/189046484-4d177f98-5b42-4ee8-91d2-0922f0fb5f46.png">
未参加のイベントの参加ボタンを押す
<img width="1470" alt="スクリーンショット 2022-09-08 15 09 59" src="https://user-images.githubusercontent.com/94046278/189047436-d1e46bc7-56e4-40ec-b39f-c118b99b5ffd.png">
参加ボタン押した後のdb情報
<img width="1470" alt="スクリーンショット 2022-09-08 15 04 00" src="https://user-images.githubusercontent.com/94046278/189046512-90dc46cc-ad8b-4014-9c40-fb66db549bca.png">
userテーブルの情報
<img width="1470" alt="スクリーンショット 2022-09-08 15 04 56" src="https://user-images.githubusercontent.com/94046278/189046576-8fffd6a9-7fd0-4b40-8d4c-5d8c937ecb13.png">
evnetテーブルの情報
<img width="1470" alt="スクリーンショット 2022-09-08 15 05 02" src="https://user-images.githubusercontent.com/94046278/189046595-efc33cf7-eed3-45ed-b612-536c7d05dbbf.png">





