### PR TITLE
#13参加者不参加者区別して保存

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -10,8 +10,9 @@ if (!isset($_SESSION["user_id"]) || !isset($_SESSION['login'])) {
 }
 
 $today = date("Y-m-d");
-$stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '" . $today . "' GROUP BY events.id " );
+$stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id " );
 $events = $stmt->fetchAll();
+// events.start_at >= '" . $today . "'
 
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
@@ -31,7 +32,7 @@ function get_day_of_week ($w) {
 </head>
 
 <body>
-  <header class="h-16">
+  <!-- <header class="h-16">
     <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
       <div class="h-full">
         <img src="img/header-logo.png" alt="" class="h-full">
@@ -40,7 +41,7 @@ function get_day_of_week ($w) {
               <a class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200" href="auth/login/logout.php">ログアウト</a>
       </div>     
     </div>
-  </header>
+  </header> -->
 
   <main class="bg-gray-100">
     <div class="w-full mx-auto p-5">
@@ -66,14 +67,23 @@ function get_day_of_week ($w) {
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           $event_id = $event['id'];
-          $stmt = $db->prepare("SELECT * FROM event_attendance LEFT JOIN events ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id where event_id = '$event_id'");
+          $stmt = $db->prepare("SELECT * FROM event_attendance LEFT JOIN events ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id where event_id = '$event_id' AND status = 1");
           $stmt->execute();
           $events_users = $stmt->fetchAll();
+
+          $stmt = $db->prepare("SELECT * FROM event_attendance LEFT JOIN events ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id where event_id = '$event_id' AND status = 2");
+          $stmt->execute();
+          $events_nousers = $stmt->fetchAll();
           ?>
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
+            <h2 class="text-lg font-semibold">参加者</h2>
               <?php foreach ($events_users as $event_user) : ?>
                 <p><?= $event_user['name']; ?></p>
+              <?php endforeach; ?>
+              <h2 class="text-lg font-semibold">不参加者</h2>
+              <?php foreach ($events_nousers as $event_nouser) : ?>
+                <p><?= $event_nouser['name']; ?></p>
               <?php endforeach; ?>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
@@ -127,3 +137,4 @@ function get_day_of_week ($w) {
 </body>
 
 </html>
+


### PR DESCRIPTION
※ 追加変更あり
## 関連イシュー
#13 

## 検証したこと
event_attendanceテーブルにstatusカラムを追加しstatus=1の時参加、status=2の時不参加としている
statusカラムで参加する人とと不参加する人を区別してdbに保存できている

- [x] DBの情報から誰が参加／不参加の予定か確認可能

## エビデンス
①元のdb情報
<img width="1470" alt="スクリーンショット 2022-09-08 14 48 05" src="https://user-images.githubusercontent.com/94046278/189044819-094ce486-694c-4291-86e5-100ab493ed75.png">
②未参加のイベント不参加押す
<img width="1470" alt="スクリーンショット 2022-09-08 14 48 14" src="https://user-images.githubusercontent.com/94046278/189044577-f74f197b-02d9-45ce-af9c-9ae464e96625.png">
③不参加押した後のテーブル
<img width="1470" alt="スクリーンショット 2022-09-08 14 48 49" src="https://user-images.githubusercontent.com/94046278/189044336-b4eb34ce-c6e8-452a-927d-108392913c35.png">
④未回答のイベント参加押す
<img width="1470" alt="スクリーンショット 2022-09-08 14 49 00" src="https://user-images.githubusercontent.com/94046278/189044353-0b9b51d1-25dd-49a9-9272-adde47590d74.png">
⑤参加押した後のテーブル
<img width="1470" alt="スクリーンショット 2022-09-08 14 50 37" src="https://user-images.githubusercontent.com/94046278/189044462-f05f3af8-32f7-4d6c-8ee3-337a24074889.png">





