### PR TITLE
#2日付順（古いもの順）に並び替えて表示するようにしました

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -10,7 +10,8 @@ if (!isset($_SESSION["user_id"]) || !isset($_SESSION['login'])) {
 }
 
 $today = date("Y-m-d");
-$stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '" . $today . "' GROUP BY events.id " );
+$stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at <= '" . $today . "' GROUP BY events.id,events.name,events.start_at,events.end_at,event_attendance.id ORDER BY events.start_at ASC" );
+$stmt->execute();
 $events = $stmt->fetchAll();
 
 function get_day_of_week ($w) {


### PR DESCRIPTION
## 関連イシュー
#2 


## 検証したこと
`ORDER BY events.start_at ASC`のコードを付け足し、開催の日付順（古いもの順）に並ぶことを確認しました

- [x] 開催日が近いもの順（過去→未来）でソートされている

## エビデンス
eventsテーブルの中身（start_atがバラバラ）
<img width="971" alt="Screen Shot 2022-09-08 at 14 53 23" src="https://user-images.githubusercontent.com/86845781/189044885-eb74ccc5-378e-49d0-bdb1-995bc242be99.png">



実際の表示画面（日付が古い順に並んでいる）
<img width="1415" alt="Screen Shot 2022-09-08 at 14 42 40" src="https://user-images.githubusercontent.com/86845781/189043529-bf710e41-712e-42b2-a1f2-5d919bcee6b5.png">
