### PR TITLE
PR#47に引き継ぎ　参加状態によりボタンを活性・非活性

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -2,7 +2,6 @@
 require('dbconnect.php');
 session_start();
 
-
 //ログインされていない場合は強制的にログインページにリダイレクト
 if (!isset($_SESSION["user_id"]) || !isset($_SESSION['login'])) {
     header("Location: auth/login/index.php");
@@ -14,10 +13,16 @@ $stmt = $db->query("SELECT events.id, events.name, events.start_at, events.end_a
 $events = $stmt->fetchAll();
 // events.start_at >= '" . $today . "'
 
+$user_id = $_SESSION['user_id'];
+$stmt = $db->prepare("SELECT * FROM event_attendance LEFT JOIN events ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id where user_id = '$user_id' AND status = 1");
+$stmt->execute();
+$events_own = $stmt->fetchAll();
+
 function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
 ?>
 
 <!DOCTYPE html>
@@ -78,13 +83,23 @@ function get_day_of_week ($w) {
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
             <h2 class="text-lg font-semibold">参加者</h2>
-              <?php foreach ($events_users as $event_user) : ?>
+            <div class="test_true">
+            <?php foreach ($events_users as $event_user) : ?>
+                <?php if($event_user['user_id'] == $user_id) :?>
+                <input type="hidden" class="hidden_true">
+                <?php endif;?>
                 <p><?= $event_user['name']; ?></p>
               <?php endforeach; ?>
               <h2 class="text-lg font-semibold">不参加者</h2>
+              <div class="test_false">
               <?php foreach ($events_nousers as $event_nouser) : ?>
+                <?php if($event_nouser['user_id'] == $user_id) :?>
+                <input type="hidden" class="hidden_false">
+                <?php endif;?>
                 <p><?= $event_nouser['name']; ?></p>
               <?php endforeach; ?>
+              </div>
+            </div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
               <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
               <p class="text-xs text-gray-600">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -10,7 +10,7 @@ for (let i = 0; i < openModalClassList.length; i++) {
   openModalClassList[i].addEventListener('click', (e) => {
     e.preventDefault()
     let eventId = parseInt(e.currentTarget.id.replace('event-', ''))
-    openModal(eventId)
+    openModal(eventId,i)
   }, false)
 }
 
@@ -21,11 +21,12 @@ for (var i = 0; i < closeModalClassList.length; i++) {
 overlay.addEventListener('click', closeModal)
 
 
-async function openModal(eventId) {
+async function openModal(eventId,index) {
   try {
     const url = '/api/getModalInfo.php?eventId=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    console.log(event)
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -51,12 +52,22 @@ async function openModal(eventId) {
             -->
           </div>
           <div class="flex mt-5">
+          `
+          const testTrue = document.querySelectorAll(".test_true");
+          const testFalse = document.querySelectorAll(".test_false");
+          if(testTrue[index].firstElementChild.classList.contains("hidden_true") == true){
+            modalHTML += `
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <!-- 
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
-            -->
           </div>
         `
+          }else if(testFalse[index].firstElementChild.classList.contains("hidden_false") == true){
+            modalHTML += `
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
+          </div>
+        `
+          }
         break;
       case 1:
         modalHTML += `

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -57,14 +57,14 @@ async function openModal(eventId,index) {
           const testFalse = document.querySelectorAll(".test_false");
           if(testTrue[index].firstElementChild.classList.contains("hidden_true") == true){
             modalHTML += `
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})" disabled>参加する</button>
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
           </div>
         `
           }else if(testFalse[index].firstElementChild.classList.contains("hidden_false") == true){
             modalHTML += `
-            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold">参加しない</button>
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled>参加しない</button>
           </div>
         `
           }


### PR DESCRIPTION
※追加変更しました。

## 引き継ぎ先PR
#47 

## 関連イシュー
#14 
イベント参加管理 Issue3 参加状態により参加／不参加ボタンを活性／非活性にする

## 検証したこと
ログインユーザーが未回答のイベントは参加ボタン・不参加ボタンともに活性し、ボタンを押すとdbに保存される
ログインユーザーが参加すると回答したイベントは不参加ボタンのみ活性とし、不参加ボタンを押すと不参加を表すstatus=2に更新される
ログインユーザーが不参加すると回答したイベントは参加ボタンのみ活性とし、参加ボタンを押すと参加を表すstatus=1に更新される

- [x] 参加予定の場合はモーダル画面の参加ボタンを非活性、不参加ボタンを活性
- [x] 不参加予定の場合はモーダル画面の参加ボタンを活性、不参加ボタンを非活性

## エビデンス
回答前の前のdb情報
<img width="1470" alt="スクリーンショット 2022-09-08 13 23 30" src="https://user-images.githubusercontent.com/94046278/189034011-5679eecf-60e4-4901-a40a-6dc5cc0bf266.png">

回答前の画面

<img width="1470" alt="スクリーンショット 2022-09-08 13 23 03" src="https://user-images.githubusercontent.com/94046278/189034043-1a2dcae8-01cd-4959-b6ce-7ce282eb23c5.png">


未回答の「かれん家で宅飲み」イベントを選択し、参加ボタンを押す

<img width="1470" alt="スクリーンショット 2022-09-08 13 23 11" src="https://user-images.githubusercontent.com/94046278/189034068-b7651dae-985e-4418-8d97-c080ae1c676f.png">


参加ボタンを押した後の画面

<img width="1470" alt="スクリーンショット 2022-09-08 13 23 39" src="https://user-images.githubusercontent.com/94046278/189034126-129e367d-b76a-456c-a71b-c8ed4b54d832.png">


参加ボタンを押した後のテーブル

<img width="1470" alt="スクリーンショット 2022-09-08 13 24 01" src="https://user-images.githubusercontent.com/94046278/189034788-305cfc0e-c7be-49b5-8af0-54ad3a9738b2.png">


参加と回答している「かれん家で宅飲み」イベントを選択し、活性している不参加ボタンを押す

<img width="1470" alt="スクリーンショット 2022-09-08 13 24 08" src="https://user-images.githubusercontent.com/94046278/189034946-8e7de1bb-e854-4258-b6cb-0cf71b48f1c8.png">


その後もう一度見てみると、参加ボタンが活性し、不参加ボタンが非活性していることを確認

<img width="1470" alt="スクリーンショット 2022-09-08 13 24 30" src="https://user-images.githubusercontent.com/94046278/189034179-7c60d972-bd43-4837-859c-adfa2c42989e.png">


参加ボタンを押した後の画面

<img width="1470" alt="スクリーンショット 2022-09-08 13 24 41" src="https://user-images.githubusercontent.com/94046278/189034234-8ac96089-3582-494d-b030-3a4983934ad8.png">


参加を押した後のテーブル

<img width="1470" alt="スクリーンショット 2022-09-08 13 24 47" src="https://user-images.githubusercontent.com/94046278/189034246-eef57ac0-d4ea-4928-b650-52c1957da6c9.png">