### PR TITLE
PR#40に引き継ぎ　トップページ参加不参加未回答表示

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -9,7 +9,7 @@ if (!isset($_SESSION["user_id"]) || !isset($_SESSION['login'])) {
 }
 
 $today = date("Y-m-d");
-$stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '" . $today . "' GROUP BY events.id,events.name,events.start_at,events.end_at,event_attendance.id ORDER BY events.start_at ASC" );
+$stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at <= '" . $today . "' GROUP BY events.id ORDER BY events.start_at ASC" );
 $stmt->execute();
 $events = $stmt->fetchAll();
 
@@ -22,6 +22,9 @@ function get_day_of_week ($w) {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
+date_default_timezone_set('Asia/Tokyo');
+$to   = strtotime("now");   
 
 ?>
 
@@ -55,6 +58,10 @@ function get_day_of_week ($w) {
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div class="flex">
+          <!-- <form action="index.php" method="post">
+            <input type="hidden" value="1">
+            <input type="submit" value="">
+          </form> -->
           <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">全て</a>
           <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
           <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
@@ -69,6 +76,9 @@ function get_day_of_week ($w) {
         <?php foreach ($events as $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
+          $diff = $start_date - $to;
+          $deadline = floor($diff/86400) . '日';
+          // echo $diff;
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           $event_id = $event['id'];
@@ -83,13 +93,14 @@ function get_day_of_week ($w) {
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
             <h2 class="text-lg font-semibold">参加者</h2>
-            <div class="test_true">
+              <div class="test_true">
             <?php foreach ($events_users as $event_user) : ?>
                 <?php if($event_user['user_id'] == $user_id) :?>
                 <input type="hidden" class="hidden_true">
-                <?php endif;?>
                 <p><?= $event_user['name']; ?></p>
+                <?php endif; ?>
               <?php endforeach; ?>
+              <input type="hidden">
               <h2 class="text-lg font-semibold">不参加者</h2>
               <div class="test_false">
               <?php foreach ($events_nousers as $event_nouser) : ?>
@@ -98,6 +109,7 @@ function get_day_of_week ($w) {
                 <?php endif;?>
                 <p><?= $event_nouser['name']; ?></p>
               <?php endforeach; ?>
+              <input type="hidden">
               </div>
             </div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
@@ -107,20 +119,20 @@ function get_day_of_week ($w) {
               </p>
             </div>
             <div class="flex flex-col justify-between text-right">
-              <div>
+              <div class="answer">
                 <?php if ($event['id'] % 3 === 1) : ?>
                   <!--
                   <p class="text-sm font-bold text-yellow-400">未回答</p>
                   <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
                   -->
                 <?php elseif ($event['id'] % 3 === 2) : ?>
-                  <!-- 
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                  -->
+                  
+                  <!-- <p class="text-sm font-bold text-gray-300">不参加</p> -->
+                 
                 <?php else : ?>
-                  <!-- 
-                  <p class="text-sm font-bold text-green-400">参加</p>
-                  -->
+                  
+                  <!-- <p class="text-sm font-bold text-green-400">参加</p> -->
+                 
                 <?php endif; ?>
               </div>
               <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加 ></p>
@@ -149,6 +161,28 @@ function get_day_of_week ($w) {
   </div>
 
   <script src="/js/main.js"></script>
+  <script>
+    const answer = document.querySelectorAll('.answer');
+for (let i = 0; i < openModalClassList.length; i++) {
+  console.log((testTrue[i].firstElementChild));
+if(testTrue[i].firstElementChild.classList.contains("hidden_true") == true){
+  let answerHTML = `
+  <p class="text-sm font-bold text-green-400">参加</p>`
+  answer[i].insertAdjacentHTML('beforeend', answerHTML);
+}else if(testFalse[i].firstElementChild.classList.contains("hidden_false") == true){
+  let answerHTML = `
+  <p class="text-sm font-bold text-gray-300">不参加</p>
+  `
+  answer[i].insertAdjacentHTML('beforeend', answerHTML);
+}else{
+  let answerHTML = `
+  <p class="text-sm font-bold text-yellow-400">未回答</p>
+  <p class="text-xs text-yellow-400">期限<?= $deadline ;?></p>
+  `
+  answer[i].insertAdjacentHTML('beforeend', answerHTML);
+}
+}
+  </script>
 </body>
 
 </html>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,6 +5,8 @@ const overlay = document.querySelector('.modal-overlay')
 const body = document.querySelector('body')
 const modal = document.querySelector('.modal')
 const modalInnerHTML = document.getElementById('modalInner')
+const testTrue = document.querySelectorAll(".test_true");
+const testFalse = document.querySelectorAll(".test_false");
 
 for (let i = 0; i < openModalClassList.length; i++) {
   openModalClassList[i].addEventListener('click', (e) => {
@@ -26,7 +28,6 @@ async function openModal(eventId,index) {
     const url = '/api/getModalInfo.php?eventId=' + eventId
     const res = await fetch(url)
     const event = await res.json()
-    console.log(event)
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -53,8 +54,6 @@ async function openModal(eventId,index) {
           </div>
           <div class="flex mt-5">
           `
-          const testTrue = document.querySelectorAll(".test_true");
-          const testFalse = document.querySelectorAll(".test_false");
           if(testTrue[index].firstElementChild.classList.contains("hidden_true") == true){
             modalHTML += `
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})" disabled>参加する</button>


### PR DESCRIPTION
※追加変更しました。

## 引き継ぎ先PR
#40 

## 関連イシュー
#15 
イベント参加管理 Issue4 トップページに自身の回答状況を表示する

## 検証したこと
ログインしているユーザーが参加している/参加していないイベントに見えない要素を追加してその要素(クラス)があるかどうかで#14と同様に参加/不参加/未回答を分岐
今日の日付とイベントごとの期限の差分で締切を表示
表示エラーがあったため改善あり

- [x] トップページの対象イベントに回答状況を表示する
まだ回答していない場合は未回答
参加の場合は参加
不参加の場合は不参加

- [x] 未回答の場合に期限表示を実装するとより良い（+1ビジネスポイント）

## エビデンス

トップページの対象イベントに回答状況を表示する
まだ回答していない場合は未回答、参加の場合は参加、不参加の場合は不参加
<img width="1470" alt="スクリーンショット 2022-09-07 11 37 16" src="https://user-images.githubusercontent.com/94046278/188776192-d8c72fcd-8464-4fcc-844f-e6f79b4f62d2.png">

未回答の場合に期限表示がされていることを確認

<img width="1470" alt="スクリーンショット 2022-09-07 11 37 24" src="https://user-images.githubusercontent.com/94046278/188776214-d45ccdef-4a3e-4bc2-a3dc-7f9563b4d7f3.png">


<img width="1470" alt="スクリーンショット 2022-09-07 11 14 39" src="https://user-images.githubusercontent.com/94046278/188773603-d07dcfe2-1c8a-43f1-bd41-5614975e3deb.png">
<img width="1470" alt="スクリーンショット 2022-09-07 11 14 36" src="https://user-images.githubusercontent.com/94046278/188773628-ee31c45b-2847-493f-b117-24938d5ab1e6.png">
<img width="1470" alt="スクリーンショット 2022-09-07 11 14 32" src="https://user-images.githubusercontent.com/94046278/188773646-887d4145-7ec8-4826-b093-f5354a2630db.png">

