### PR TITLE
PR#37から引き継ぎ　#15トップページに回答状況表示

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -78,7 +78,6 @@ $to   = strtotime("now");
           $start_date = strtotime($event['start_at']);
           $diff = $start_date - $to;
           $deadline = floor($diff/86400) . '日';
-          // echo $diff;
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           $event_id = $event['id'];
@@ -94,11 +93,12 @@ $to   = strtotime("now");
             <div>
             <h2 class="text-lg font-semibold">参加者</h2>
               <div class="test_true">
-            <?php foreach ($events_users as $event_user) : ?>
+            <?php foreach ($events_users as $event_user) : 
+              ?>
                 <?php if($event_user['user_id'] == $user_id) :?>
                 <input type="hidden" class="hidden_true">
-                <p><?= $event_user['name']; ?></p>
                 <?php endif; ?>
+                <p><?= $event_user['name']; ?></p>
               <?php endforeach; ?>
               <input type="hidden">
               <h2 class="text-lg font-semibold">不参加者</h2>


### PR DESCRIPTION
※ 追加証跡あり

## 引き継ぎ元PR
#37 

## 関連イシュー
#15 

## 検証したこと
dbの情報から回答していない場合は未回答を表示、参加の場合は参加、不参加の場合は不参加を表示
未回答の場合は期限(イベントの３日前の日付)を表示

- [x] トップページの対象イベントに回答状況を表示する
まだ回答していない場合は未回答
参加の場合は参加
不参加の場合は不参加

- [x] 未回答の場合に期限表示を実装するとより良い（+1ビジネスポイント）

## エビデンス
event_attendanceテーブル
<img width="1470" alt="スクリーンショット 2022-09-08 13 36 07" src="https://user-images.githubusercontent.com/94046278/189035372-f0ad4566-84dc-4a9e-96e0-ef177aab6dbf.png">
usersテーブル
<img width="1470" alt="スクリーンショット 2022-09-08 13 36 11" src="https://user-images.githubusercontent.com/94046278/189035393-58de7156-308a-4c60-babc-6f5ad52a71c0.png">
eventsテーブル
<img width="1470" alt="スクリーンショット 2022-09-08 15 24 31" src="https://user-images.githubusercontent.com/94046278/189049694-32ae1b06-b367-48f6-8e77-6de7d9fac432.png">
参加不参加表示
<img width="1470" alt="スクリーンショット 2022-09-08 13 36 42" src="https://user-images.githubusercontent.com/94046278/189035437-393ff772-1c19-497d-a032-33ade2e4e370.png">
未回答の場合期限表示
<img width="1470" alt="スクリーンショット 2022-09-08 13 36 59" src="https://user-images.githubusercontent.com/94046278/189035456-7302a413-1164-4a34-ba77-3391538adb14.png">

