### PR TITLE
#17通知機能の参加者出力

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -13,10 +13,10 @@ $today = date("Y-m-d");
 // 参加/不参加/未回答の分類→未参加のみあとで書き加える
 $status = filter_input(INPUT_GET, 'status');
 if (isset($status)) {
-  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at <= '" . $today . "' AND event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC" );
+  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '" . $today . "' AND event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC" );
   $stmt->execute(array($_SESSION['user_id'], $status));
 }else{
-  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at <= '" . $today . "' GROUP BY events.id ORDER BY events.start_at ASC" );
+  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= '" . $today . "' GROUP BY events.id ORDER BY events.start_at ASC" );
   $stmt->execute();
 }
 $events = $stmt->fetchAll();


### PR DESCRIPTION
（コミットの変更内容はissueに関係ありません）

## 関連イシュー
#17 

## 検証したこと
ターミナルで
```
SELECT events.name, events.start_at, users.name 
FROM events
LEFT JOIN event_attendance ON event_attendance.event_id = events.id 
LEFT JOIN users ON event_attendance.user_id = users.id
WHERE events.start_at >= CURDATE() AND event_attendance.status=1;
```
と入力し、処理日以降に開催予定のイベント情報が以下の出力イメージのように表示されるか確かめました。


- [x] どのイベントに誰が参加するのか確認できる
- [x] 1回のSQLで処理日以降に開催される全てのイベントの情報が取得できる

■出力のイメージ（SQL結果に以下の情報が含まれていればOKです。ヘッダー、フッター書式は特に問いません）
Aイベント　1999/01/01　信田健児
Aイベント　1999/01/01　橋本満
Bイベント　1999/01/01　信田健児
Bイベント　1999/01/01　橋本満

## エビデンス
<img width="697" alt="Screen Shot 2022-09-07 at 15 46 35" src="https://user-images.githubusercontent.com/86845781/188808248-4a00b7b7-3bf4-4250-ad17-1396ea1f6834.png">




↓参考：今日以降に開催予定のイベント一覧、event_attendanceの一覧（status=1を「参加」としています）
<img width="1213" alt="Screen Shot 2022-09-07 at 14 05 18" src="https://user-images.githubusercontent.com/86845781/188792975-c76d5e66-c456-4e1a-8251-406db6c4cd05.png">

