### PR TITLE
#22 管理画面 Issue2 画面からイベント内容も登録出来るようにする

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -2,6 +2,7 @@
 -- CREATE SCHEMA posse;
 -- USE posse;
 
+
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 START TRANSACTION;
 SET time_zone = "+00:00";
@@ -25,7 +26,7 @@ SET time_zone = "+00:00";
 CREATE TABLE `events` (
   `id` int NOT NULL,
   `name` varchar(10) COLLATE utf8_unicode_ci NOT NULL,
-  `detail` varchar(255) COLLATE utf8_unicode_ci,
+  `detail` text CHARACTER SET utf8 COLLATE utf8_unicode_ci,
   `start_at` datetime DEFAULT NULL,
   `end_at` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
@@ -61,7 +62,10 @@ INSERT INTO `events` (`id`, `name`, `detail`, `start_at`, `end_at`, `created_at`
 (21, 'ハッカソン', '', '2022-10-01 10:00:00', '2022-10-01 22:00:00', '2022-09-06 12:20:48', '2022-09-06 12:20:48', NULL),
 (22, '遊び', '', '2022-10-01 18:00:00', '2022-10-01 22:00:00', '2022-09-06 12:20:48', '2022-09-06 12:20:48', NULL),
 (23, 'かれんちで宅飲み', '', '2022-09-08 15:31:00', '2022-09-08 15:31:00', '2022-09-07 15:31:27', '2022-09-07 06:37:03', NULL),
-(24, 'おのかん家は快適？', '', '2022-09-08 15:35:00', '2022-09-08 18:35:00', '2022-09-07 15:35:42', '2022-09-07 06:35:42', NULL);
+(24, 'おのかん家は快適？', '', '2022-09-08 15:35:00', '2022-09-08 18:35:00', '2022-09-07 15:35:42', '2022-09-07 06:35:42', NULL),
+(25, 'all期生イベント', NULL, '2022-09-07 15:59:00', '2022-09-07 16:59:00', '2022-09-07 15:59:18', '2022-09-07 06:59:18', NULL),
+(42, 'サイゼリヤ食べ放題', NULL, '2022-09-08 16:27:00', '2022-09-08 17:27:00', '2022-09-07 16:28:05', '2022-09-07 07:28:05', NULL),
+(43, '二次会＠料理倶楽部', '料理倶楽部で二次会します。\r\nシンプルに楽しいと思います。', '2022-09-08 16:44:00', '2022-09-08 18:44:00', '2022-09-07 16:44:50', '2022-09-07 07:44:50', NULL);
 
 -- --------------------------------------------------------
 
@@ -149,7 +153,7 @@ ALTER TABLE `users`
 -- テーブルの AUTO_INCREMENT `events`
 --
 ALTER TABLE `events`
-  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=25;
+  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=44;
 
 --
 -- テーブルの AUTO_INCREMENT `event_attendance`

--- a/src/admin/register_event.php
+++ b/src/admin/register_event.php
@@ -24,7 +24,8 @@ session_start();
             <h2 class="text-md font-bold mb-5">イベント登録登録</h2>
             <form class="flex flex-col" action="../store.php" method="POST">
                 <input type="text" name="name" placeholder="イベント名" class="w-full p-4 text-sm mb-3" required>
-                <input type="textarea" name="detail" placeholder="イベント内容" class="w-full p-4 text-sm mb-2 h-14 rounded">
+                <p class="mb-0 mt-3">イベント内容</p>
+                <textarea class="w-full p-4 text-sm mb-4 rounded" name="detail" rows="7" cols="150"></textarea>
                 <p class="mb-0 mt-3">開始日時</p>
                 <input name="start_at" placeholder="<?php echo date('Y-m-d H:i:s'); ?>" class="w-full p-4 text-sm mb-3"  type="datetime-local" required>
                 <p class="mb-0 mt-3">終了日時</p>

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -5,14 +5,18 @@ header('Content-Type: application/json; charset=UTF-8');
 if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
   try {
-    $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
+    $stmt = $db->prepare('SELECT events.id, events.name, events.detail, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
     $stmt->execute(array($eventId));
     $event = $stmt->fetch();
     
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
 
+    if ($event['detail'] == null) {
     $eventMessage = date("Y年m月d日", $start_date) . '（' . get_day_of_week(date("w", $start_date)) . '） ' . date("H:i", $start_date) . '~' . date("H:i", $end_date) . 'に' . $event['name'] . 'を開催します。<br>ぜひ参加してください。';
+    } else {
+      $eventMessage = $event['detail'];
+    };
 
     if ($event['id'] % 3 === 1) $status = 0;
     elseif ($event['id'] % 3 === 2) $status = 1;

--- a/src/store.php
+++ b/src/store.php
@@ -5,14 +5,14 @@ require(dirname(__FILE__) . "/dbconnect.php");
 // $user_id = $_SESSION['user_id'];
 $date = date("Y-m-d H:i:s");
 $name = $_POST['name'];
-// $detail = $_POST['detail'];
+$detail = $_POST['detail'];
 
 if(isset($_POST['name'])){
     $start_at = $_POST['start_at'];
     $_SESSION['start_at'] = $start_at;
     $end_at = $_POST['end_at'];
     $_SESSION['end_at'] = $end_at;
-    $stmt = $db->prepare("INSERT INTO events (name, start_at, end_at,created_at) VALUES ('$name', '$start_at','$end_at','$date')");
+    $stmt = $db->prepare("INSERT INTO events (name, detail, start_at, end_at,created_at) VALUES ('$name', '$detail', '$start_at','$end_at','$date')");
     $stmt->execute();
     header('Location: admin/index.php');
     exit();


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#22 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->

①イベント登録画面からイベント名、イベント内容などの項目を入力し登録ボタンを押下
②eventsテーブルのレコードに先ほど入力した情報が追加されていることを確認
③ユーザー画面トップページでイベント、内容が表示されていることを確認

- [x] 管理画面からイベント名、開催日時、イベント内容を入力して、イベント登録できる
- [x] 管理画面には管理者のみログイン出来る

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->

①イベント登録画面からイベント名、イベント内容などの項目を入力し登録ボタンを押下

![image](https://user-images.githubusercontent.com/86884063/188822601-168c2759-98a1-4a1c-8748-ca4f2ca3459a.png)

②eventsテーブルのレコードに先ほど入力した情報が追加されていることを確認

![image](https://user-images.githubusercontent.com/86884063/188822960-4251599b-1afc-4fff-8d57-74b791b54b33.png)

③ユーザー画面トップページでイベント、内容が表示されていることを確認

![image](https://user-images.githubusercontent.com/86884063/188823226-798db57d-79b9-41e4-a193-dde518c9aaa6.png)

## 補足

- eventsテーブルのdetailカラムがnullだった場合はデフォルトの文章が表示されるようにして、レコードがある場合はその文章が表示されるようにしました。
![image](https://user-images.githubusercontent.com/86884063/188829111-4c46ab7e-24bb-45b6-be88-d2e8e39bdf5c.png)

 - 改行の記述ができるように、textareaタグを使用して入力画面を作成しました。


