### PR TITLE
#18 通知機能 Issue2 イベントの前日にメールで通知する 通知する先はユーザレコードの人すべて

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   mailhog:
     image: mailhog/mailhog
     ports:
-      - "8025:8025"
+      - "8024:8025"
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     depends_on:

--- a/src/sendmail.php
+++ b/src/sendmail.php
@@ -1,0 +1,49 @@
+<?php
+require('dbconnect.php');
+
+date_default_timezone_set('Asia/Tokyo');
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+
+$stmt = $db->prepare("SELECT * FROM users");
+$stmt->execute();
+$users = $stmt->fetchAll();
+
+// $date  = date("Ymd",strtotime("-1 day"));
+$start_date  = date('Y-m-d 00:00:00',strtotime("+1 day"));
+$end_date  = date('Y-m-d 23:59:59',strtotime("+1 day"));
+
+$stmt2 = $db->prepare("SELECT * FROM events where '$start_date' < start_at AND start_at < '$end_date'");
+$stmt2->execute();
+$events = $stmt2->fetchAll();
+
+foreach ($events as $event) {
+foreach ($users as $user) {
+
+$to = $user['email'];
+$subject = "posseイベント前日メール" ;
+$body = "本文";
+$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+
+$name = $user['name'];
+$date = $event['start_at'];
+$event_name = $event['name'];
+$detail = $event['detail'];
+$body = <<<EOT
+{$name}さん
+
+${date}に${event_name}を開催します。
+
+イベント内容↓↓↓
+${detail}
+
+ぜひ来てください！！！
+
+EOT;
+
+mb_send_mail($to, $subject, $body, $headers);
+}
+}
+echo "メールを送信しました";
+


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#18 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
①ターミナル内でphp sendmail.php を実行するとメールが送信される
②全てのユーザーにメールが送信されていることを確認
③明日(2022/09/08)のイベントがあっていることを確認
 
- [x] バッチを実行すると処理日がイベントの前日の場合メールを送付する
- [x] メールの宛先はユーザレコードの人全て
- [x] メールにはイベント名、内容、開催日時を記載する

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
①ターミナル内でphp sendmail.php を実行するとメールが送信される
![image](https://user-images.githubusercontent.com/86884063/188869002-0866769a-d6ad-4d30-8412-7eac164d131c.png)


②全てのユーザーにメールが送信されていることを確認
![image](https://user-images.githubusercontent.com/86884063/188869079-b95072e2-2b8f-426b-8c93-6a4a3e394763.png)

![image](https://user-images.githubusercontent.com/86884063/188869137-8a663359-5984-47c0-a908-3a9f8f3f2350.png)


③明日(2022/09/08)のイベントがあっていることを確認
![image](https://user-images.githubusercontent.com/86884063/188869278-e9f1694d-06a3-4145-a5f5-504d9ffd8747.png)

![image](https://user-images.githubusercontent.com/86884063/188869440-bf0cc83b-ef63-4ac6-9598-6c6989684f9d.png)

