### PR TITLE
#19 通知機能 Issue3 イベントの前日にメールで通知する 通知する先は参加としている人のみ#19

### DIFF
--- a/src/sendmail.php
+++ b/src/sendmail.php
@@ -21,13 +21,15 @@ foreach ($events as $event) {
 foreach ($users as $user) {
 
 $to = $user['email'];
-$subject = "posseイベント前日メール" ;
+$event_name = $event['name'];
+$subject = <<<EOT
+    ${event_name}前日リマインドメール 
+    EOT;
 $body = "本文";
 $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
 
 $name = $user['name'];
 $date = $event['start_at'];
-$event_name = $event['name'];
 $detail = $event['detail'];
 $body = <<<EOT
 {$name}さん

--- a/src/sendmail.php
+++ b/src/sendmail.php
@@ -1,46 +1,48 @@
 <?php
 require('dbconnect.php');
-
 date_default_timezone_set('Asia/Tokyo');
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
-$start_date  = date('Y-m-d 00:00:00', strtotime("+1 day"));
-$end_date  = date('Y-m-d 23:59:59', strtotime("+1 day"));
 
-$stmt = $db->prepare("SELECT events.start_at, events.name AS event_name, events.detail, users.email, users.name FROM events
-LEFT JOIN event_attendance ON event_attendance.event_id = events.id 
-LEFT JOIN users ON event_attendance.user_id = users.id
-WHERE '$start_date' < events.start_at 
-AND events.start_at < '$end_date' 
-AND event_attendance.status = 1
-");
+$stmt = $db->prepare("SELECT * FROM users");
 $stmt->execute();
 $users = $stmt->fetchAll();
 
-    foreach ($users as $user) {
+// $date  = date("Ymd",strtotime("-1 day"));
+$start_date  = date('Y-m-d 00:00:00',strtotime("+1 day"));
+$end_date  = date('Y-m-d 23:59:59',strtotime("+1 day"));
 
-        $to = $user['email'];
-        $subject = "posseイベント前日メール";
-        $body = "本文";
-        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+$stmt2 = $db->prepare("SELECT * FROM events where '$start_date' < start_at AND start_at < '$end_date'");
+$stmt2->execute();
+$events = $stmt2->fetchAll();
 
-        $name = $user['name'];
-        $date = $user['start_at'];
-        $event_name = $user['event_name'];
-        $detail = $user['detail'];
-        $body = <<<EOT
+foreach ($events as $event) {
+foreach ($users as $user) {
+
+$to = $user['email'];
+$subject = "posseイベント前日メール" ;
+$body = "本文";
+$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+
+$name = $user['name'];
+$date = $event['start_at'];
+$event_name = $event['name'];
+$detail = $event['detail'];
+$body = <<<EOT
 {$name}さん
 
-参加予定の「${event_name}」の前日となりました。
-${date}に始まります！
+
+明日の ${date}に ${event_name}を開催します。
 
 【イベント内容】
 ${detail}
 
+
+ぜひ来てください！！！
 EOT;
 
-        mb_send_mail($to, $subject, $body, $headers);
-    }
-
+mb_send_mail($to, $subject, $body, $headers);
+}
+}
 echo "メールを送信しました";

--- a/src/sendmail.php
+++ b/src/sendmail.php
@@ -5,45 +5,42 @@ date_default_timezone_set('Asia/Tokyo');
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
+$start_date  = date('Y-m-d 00:00:00', strtotime("+1 day"));
+$end_date  = date('Y-m-d 23:59:59', strtotime("+1 day"));
 
-$stmt = $db->prepare("SELECT * FROM users");
+$stmt = $db->prepare("SELECT events.start_at, events.name AS event_name, events.detail, users.email, users.name FROM events
+LEFT JOIN event_attendance ON event_attendance.event_id = events.id 
+LEFT JOIN users ON event_attendance.user_id = users.id
+WHERE '$start_date' < events.start_at 
+AND events.start_at < '$end_date' 
+AND event_attendance.status = 1
+");
 $stmt->execute();
 $users = $stmt->fetchAll();
 
-// $date  = date("Ymd",strtotime("-1 day"));
-$start_date  = date('Y-m-d 00:00:00',strtotime("+1 day"));
-$end_date  = date('Y-m-d 23:59:59',strtotime("+1 day"));
+    foreach ($users as $user) {
 
-$stmt2 = $db->prepare("SELECT * FROM events where '$start_date' < start_at AND start_at < '$end_date'");
-$stmt2->execute();
-$events = $stmt2->fetchAll();
+        $to = $user['email'];
+        $subject = "posseイベント前日メール";
+        $body = "本文";
+        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
 
-foreach ($events as $event) {
-foreach ($users as $user) {
-
-$to = $user['email'];
-$subject = "posseイベント前日メール" ;
-$body = "本文";
-$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-
-$name = $user['name'];
-$date = $event['start_at'];
-$event_name = $event['name'];
-$detail = $event['detail'];
-$body = <<<EOT
+        $name = $user['name'];
+        $date = $user['start_at'];
+        $event_name = $user['event_name'];
+        $detail = $user['detail'];
+        $body = <<<EOT
 {$name}さん
 
-${date}に${event_name}を開催します。
+参加予定の「${event_name}」の前日となりました。
+${date}に始まります！
 
-イベント内容↓↓↓
+【イベント内容】
 ${detail}
-
-ぜひ来てください！！！
 
 EOT;
 
-mb_send_mail($to, $subject, $body, $headers);
-}
-}
-echo "メールを送信しました";
+        mb_send_mail($to, $subject, $body, $headers);
+    }
 
+echo "メールを送信しました";

--- a/src/sendmail2.php
+++ b/src/sendmail2.php
@@ -1,0 +1,46 @@
+<?php
+require('dbconnect.php');
+
+date_default_timezone_set('Asia/Tokyo');
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+$start_date  = date('Y-m-d 00:00:00', strtotime("+1 day"));
+$end_date  = date('Y-m-d 23:59:59', strtotime("+1 day"));
+
+$stmt = $db->prepare("SELECT events.start_at, events.name AS event_name, events.detail, users.email, users.name FROM events
+LEFT JOIN event_attendance ON event_attendance.event_id = events.id 
+LEFT JOIN users ON event_attendance.user_id = users.id
+WHERE '$start_date' < events.start_at 
+AND events.start_at < '$end_date' 
+AND event_attendance.status = 1
+");
+$stmt->execute();
+$users = $stmt->fetchAll();
+
+    foreach ($users as $user) {
+
+        $to = $user['email'];
+        $subject = "posseイベント前日メール";
+        $body = "本文";
+        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+        $name = $user['name'];
+        $date = $user['start_at'];
+        $event_name = $user['event_name'];
+        $detail = $user['detail'];
+        $body = <<<EOT
+{$name}さん
+
+参加予定の「${event_name}」の前日となりました。
+${date}に始まります！
+
+【イベント内容】
+${detail}
+
+EOT;
+
+        mb_send_mail($to, $subject, $body, $headers);
+    }
+
+echo "メールを送信しました";

--- a/src/sendmail2.php
+++ b/src/sendmail2.php
@@ -21,13 +21,15 @@ $users = $stmt->fetchAll();
     foreach ($users as $user) {
 
         $to = $user['email'];
-        $subject = "posseイベント前日メール";
+        $event_name = $user['event_name'];
+        $subject = <<<EOT
+            ${event_name}前日リマインド 
+            EOT;        
         $body = "本文";
         $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
 
         $name = $user['name'];
         $date = $user['start_at'];
-        $event_name = $user['event_name'];
         $detail = $user['detail'];
         $body = <<<EOT
 {$name}さん


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#19 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
①phpコンテナ内のターミナルでphp sendmail.phpを実行し、メールを送信
②mailhogにて、翌日のイベントに参加する予定のメンバーのみにメールが届いていることを確認
③メールにイベント名、内容、開催日時が記載されていることを確認

- [x] バッチを実行すると処理日がイベントの前日の場合メールを送付する
- [x] メールの宛先は参加としている人のみ
- [x] メールにはイベント名、内容、開催日時を記載する

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->

①phpコンテナ内のターミナルでphp sendmail2.phpを実行し、メールを送信

![image](https://user-images.githubusercontent.com/86884063/188899424-de1f8410-d660-46bb-998a-efb681fe6b7d.png)


②mailhogにて、翌日のイベントに参加する予定のメンバーのみにメールが届いていることを確認

![image](https://user-images.githubusercontent.com/86884063/188899534-69727ec4-e08c-48d6-8b09-af95b7092658.png)


③メールにイベント名、内容、開催日時が記載されていることを確認


![image](https://user-images.githubusercontent.com/86884063/188900007-e887a244-5b13-4a5b-8db8-34c16b853836.png)


## 補足

テーブル情報です。

`eventsテーブル`

![image](https://user-images.githubusercontent.com/86884063/188900202-fa6584ca-1cd7-4bc7-8ab7-9e466c5459b5.png)


`usersテーブル`

![image](https://user-images.githubusercontent.com/86884063/188900449-d6b50a3a-d3e3-489f-83fa-c4ce72270c4e.png)

`event_attendanceテーブル`

![image](https://user-images.githubusercontent.com/86884063/188900556-18bac666-0d22-4541-8917-5a2e7cedb164.png)

status = 1が参加、2が不参加です。

