### PR TITLE
#26 未回答管理 Issue3 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ

### DIFF
--- a/src/sendmail4.php
+++ b/src/sendmail4.php
@@ -26,16 +26,15 @@ $users = $stmt->fetchAll();
 foreach ($users as $user) {
 
     $to = $user['email'];
-    $event_name = $event['name'];
+    $event_name = $user['event_name'];
     $subject = <<<EOT
     ${event_name}　3日前参加可否リマインドメール 
     EOT;
     $body = "本文";
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
-
     $name = $user['name'];
-    $date = $event['start_at'];
-    $detail = $event['detail'];
+    $date = $user['start_at'];
+    $detail = $user['detail'];
     $body = <<<EOT
 {$name}さん
 

--- a/src/sendmail4.php
+++ b/src/sendmail4.php
@@ -1,0 +1,58 @@
+<?php
+require('dbconnect.php');
+
+date_default_timezone_set('Asia/Tokyo');
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+$start_date  = date('Y-m-d 00:00:00', strtotime("+3 day"));
+$end_date  = date('Y-m-d 23:59:59', strtotime("+3 day"));
+
+$stmt = $db->prepare("SELECT events.name event_name, events.detail, events.start_at, users.*
+FROM  events 
+CROSS JOIN users
+WHERE '$start_date' < start_at 
+AND start_at < '$end_date'
+and not exists (
+select * from event_attendance ea
+    where ea.user_id = users.id
+    and ea.event_id = events.id
+    )  
+ORDER BY `event_name` ASC;
+");
+$stmt->execute();
+$users = $stmt->fetchAll();
+
+foreach ($users as $user) {
+
+    $to = $user['email'];
+    $event_name = $event['name'];
+    $subject = <<<EOT
+    ${event_name}　3日前参加可否リマインドメール 
+    EOT;
+    $body = "本文";
+    $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+    $name = $user['name'];
+    $date = $event['start_at'];
+    $detail = $event['detail'];
+    $body = <<<EOT
+{$name}さん
+
+3日後の ${date}に << ${event_name} >>を開催します。
+
+このメールは、posseアプリでの参加可否が未回答の方にむけたリマインドのメールです。
+今すぐ下記リンクより参加可否の登録お願いします！！
+https://event.posse-ap.com/login
+
+【イベント内容】
+${detail}
+
+
+ぜひ来てください！！！
+EOT;
+
+    mb_send_mail($to, $subject, $body, $headers);
+}
+
+echo "メールを送信しました";


### PR DESCRIPTION
## 関連イシュー
#26 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
①phpコンテナ内ターミナルでバッチを実行すると処理日がイベントの3日前の場合メールが送付されることを確認
②mailhogにて、3日後のリマインドメールが未回答としている人のみに送信されていることを確認
③メールにイベント名、内容、開催日時、回答を促す内容が記載されていることを確認


- [x] バッチを実行すると処理日がイベントの3日前の場合メールを送付する
- [x] メールの宛先は未回答としている人のみ
- [x] メールにはイベント名、内容、開催日時、回答を促す内容を記載する

## エビデンス
①phpコンテナ内ターミナルでバッチを実行すると処理日がイベントの3日前の場合メールが送付されることを確認

![image](https://user-images.githubusercontent.com/86884063/188956456-5be6a34e-7ce8-4566-ab57-753cc47f65d4.png)


②mailhogにて、3日後のリマインドメールが未回答としている人のみに送信されていることを確認

![image](https://user-images.githubusercontent.com/86884063/188956525-0fc69be0-781f-4449-bfcf-1d0dd08e8615.png)

<eventsテーブル>
現時点(2022-09-08)での場合、2022-09-11開催予定の「タワタワ0911」がメールの対象のイベントとなる。
![image](https://user-images.githubusercontent.com/86884063/188957115-d38763ad-ce08-4f6c-b8a9-2c4c3a9ebb66.png)

<event_attendanceテーブル>
2022-09-11開催予定の「タワタワ0911」はevent_id = 45
event_id = 45 のレコードで status = 1 または 2 を持っているユーザー(1が参加予定、2が不参加予定)以外のuser_id、つまりuser_id = usersテーブルのid = 5,6のメンバーにメールが届いていれば良い。

![image](https://user-images.githubusercontent.com/86884063/188957035-2103de02-c421-453d-a6c1-72df39858206.png)

<usersテーブル>
id = 5,6の二人にメールが届いてることが2枚目の画像からわかる。
![image](https://user-images.githubusercontent.com/86884063/188957858-e065f0d7-ecb5-473b-a663-f5d5fdb9885a.png)


③メールにイベント名、内容、開催日時、回答を促す内容が記載されていることを確認

![image](https://user-images.githubusercontent.com/86884063/188956857-35d7831b-530c-4bd2-aa13-5fa30ffe3d2a.png)
