### PR TITLE
#27 last issue 未回答管理 Issue4 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ slack通知

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -50,9 +50,9 @@ INSERT INTO `events` (`id`, `name`, `detail`, `start_at`, `end_at`, `created_at`
 (24, 'おのかん家は快適？', 'おのかんちは快適なのか、みんなで検証する会です。　男子は2000円/人、女子は4000円/人です。 楽しい会にしましょう！！！！！！！！！男子は2000円/人、女子は4000円/人です。 楽しい会にしましょう！！！！！！！！！', '2022-09-12 15:35:00', '2022-09-12 21:00:00', '2022-09-07 15:35:42', '2022-09-08 06:44:36', NULL),
 (25, 'all期生イベント', '男子は2000円/人、女子は4000円/人です。\n楽しい会にしましょう！！！！！！！！！', '2022-09-07 15:59:00', '2022-09-07 16:59:00', '2022-09-07 15:59:18', '2022-09-07 13:20:43', NULL),
 (42, 'サイゼリヤ食べ放題', '男子は2000円/人、女子は4000円/人です。\n楽しい会にしましょう！！！！！！！！！', '2022-09-10 16:27:00', '2022-09-10 17:27:00', '2022-09-07 16:28:05', '2022-09-08 06:46:20', NULL),
-(43, '二次会＠料理倶楽部', '料理倶楽部で二次会します。\r\nシンプルに楽しいと思います。', '2022-09-11 00:00:00', '2022-09-11 18:44:00', '2022-09-07 16:44:50', '2022-09-08 06:43:12', NULL),
+(43, '二次会＠料理倶楽部', '料理倶楽部で二次会します。\r\nシンプルに楽しいと思います。', '2022-09-11 09:00:00', '2022-09-11 18:44:00', '2022-09-07 16:44:50', '2022-09-08 07:34:55', NULL),
 (44, '料理倶楽部３次会', '料理倶楽部で３次会やります。\n男子は2000円/人、女子は4000円/人です。\n楽しい会にしましょう！！！！！！！！！！', '2022-09-08 18:00:00', '2022-09-08 23:00:00', '2022-09-07 16:56:43', '2022-09-07 11:09:03', NULL),
-(45, 'タワタワ 0909', 'タワーtoタワーです。\r\n楽しいです。\r\n歩きましょう。', '2022-09-09 03:18:00', '2022-09-09 08:18:00', '2022-09-08 03:19:00', '2022-09-08 06:46:30', NULL),
+(45, 'タワタワ 0909', 'タワーtoタワーです。\r\n楽しいです。\r\n歩きましょう。', '2022-09-09 03:18:00', '2022-09-09 08:18:00', '2022-09-08 03:19:00', '2022-09-08 07:02:51', NULL),
 (46, 'なおきが施す会912', 'なおきに施される会。\r\nそのままです。\r\n全員無料です。', '2022-09-12 16:20:00', '2022-09-12 22:20:00', '2022-09-08 03:20:27', '2022-09-07 18:20:27', NULL);
 
 -- --------------------------------------------------------
@@ -90,16 +90,17 @@ INSERT INTO `event_attendance` (`id`, `event_id`, `user_id`, `created_at`, `upda
 (12, 42, 3, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2),
 (13, 42, 4, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2),
 (14, 44, 6, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2),
-(15, 43, 1, '2022-09-06 12:20:48', '2022-09-07 09:25:38', NULL, 1),
 (16, 43, 2, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 1),
 (17, 43, 3, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2),
 (18, 43, 5, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2),
 (19, 45, 2, '2022-09-06 12:20:48', '2022-09-08 06:47:08', NULL, 1),
 (20, 45, 3, '2022-09-06 12:20:48', '2022-09-08 06:47:11', NULL, 1),
 (21, 45, 1, '2022-09-06 12:20:48', '2022-09-08 06:48:56', NULL, 2),
-(22, 45, 6, '2022-09-06 12:20:48', '2022-09-08 06:44:00', NULL, 2),
+(22, 45, 6, '2022-09-06 12:20:48', '2022-09-08 07:47:12', NULL, 1),
 (23, 46, 5, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 1),
-(24, 46, 6, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2);
+(24, 46, 6, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2),
+(25, 44, 2, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 1),
+(26, 45, 3, '2022-09-06 12:20:48', '2022-09-07 09:26:40', NULL, 2);
 
 -- --------------------------------------------------------
 
@@ -112,7 +113,7 @@ CREATE TABLE `users` (
   `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `login_pass` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-  `slack_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `slack_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `github_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `role_id` int NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
@@ -125,9 +126,9 @@ INSERT INTO `users` (`id`, `name`, `email`, `login_pass`, `slack_id`, `github_id
 (1, 'かしけん', 'kashiken@kashiken', '$2y$10$Irq4dHv0LhOPhTbX0VlQv.VMWHhn4SZ6hg171NkK95r9H57X4kRaG', 'U041KN8C6TW', 'kashiken4869', 2),
 (2, 'かれん', 'karen@kk', '$2y$10$7EYUohG.DqNb.tLpvvub9esviI3baz3y/p01YsmD/cRaKUS6/ZdQG', 'U042729EW64', 'karen-812', 1),
 (3, 'ポンタ', 'ponta@p', '$2y$10$7EYUohG.DqNb.tLpvvub9esviI3baz3y/p01YsmD/cRaKUS6/ZdQG', 'U041HQCGYLB', 'ponta10', 1),
-(4, '姑', 'email@email', '$2y$10$CCzvVNIVoilFoqhYtnVu7etRL4R93AvmpWSkr522zreotkdvEsc72', 'U042729EW64', 'U042729EW64', 2),
-(5, 'りさ', 'lisa@lisa', '$2y$10$sCTDksa1CGZXtlFp5RMjQOdbHpmUMY92.MpSAmR1jKxwQqb6npUka', 'U042729EW64', 'U042729EW64', 2),
-(6, 'あきら', 'akira@uber', '$2y$10$eg6OvKvjSUsXLFdSbFe6P.jliQ7sT1TjT.GBM.15DaaaPtDImBSgG', 'U041KN8C6TW', 'akira', 1);
+(4, '姑', 'email@email', '$2y$10$CCzvVNIVoilFoqhYtnVu7etRL4R93AvmpWSkr522zreotkdvEsc72', NULL, 'U042729EW64', 2),
+(5, 'りさ', 'lisa@lisa', '$2y$10$sCTDksa1CGZXtlFp5RMjQOdbHpmUMY92.MpSAmR1jKxwQqb6npUka', NULL, 'U042729EW64', 2),
+(6, 'あきら', 'akira@uber', '$2y$10$eg6OvKvjSUsXLFdSbFe6P.jliQ7sT1TjT.GBM.15DaaaPtDImBSgG', NULL, 'akira', 1);
 
 --
 -- ダンプしたテーブルのインデックス
@@ -165,7 +166,7 @@ ALTER TABLE `events`
 -- テーブルの AUTO_INCREMENT `event_attendance`
 --
 ALTER TABLE `event_attendance`
-  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=25;
+  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=29;
 
 --
 -- テーブルの AUTO_INCREMENT `users`

--- a/src/sendmail2.php
+++ b/src/sendmail2.php
@@ -45,9 +45,10 @@ EOT;
 
     mb_send_mail($to, $subject, $body, $headers);
 
-$url = "https://hooks.slack.com/services/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";
+$url = "https://hooks.slack.com/services/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";
 
 // メッセージ
+if ( $slack_id != NULL ) {
 $message = array(
     "username"   => "POSSEイベント 前日リマインド",
     "icon_emoji" => ":slack:",
@@ -73,6 +74,7 @@ curl_setopt($ch, CURLOPT_POSTFIELDS, $message_post);
 curl_exec($ch);
 curl_close($ch);
 
+}
 }
 
 echo "メールを送信しました";

--- a/src/sendmail4.php
+++ b/src/sendmail4.php
@@ -26,6 +26,7 @@ $users = $stmt->fetchAll();
 foreach ($users as $user) {
 
     $to = $user['email'];
+    $slack_id = $user['slack_id'];
     $event_name = $user['event_name'];
     $subject = <<<EOT
     ${event_name}　3日前参加可否リマインドメール 
@@ -52,6 +53,35 @@ ${detail}
 EOT;
 
     mb_send_mail($to, $subject, $body, $headers);
+
+$url = "https://hooks.slack.com/services/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";
+
+// メッセージ
+if ( $slack_id != NULL ) {
+$message = array(
+    "username"   => "POSSEイベント 3日前リマインド",
+    "icon_emoji" => ":slack:",
+    "attachments" => array(
+        array(
+            "text" => "<@${slack_id}> \n 3日後に「${event_name}」が開催されます。 \n ${date} から開催です。 \n posseアプリでの参加可否が未回答の方にむけたリマインドの通知です。\n 今すぐ下記リンクより参加可否の登録お願いします！！ \n https://event.posse-ap.com/login \n 【イベント内容】\n ${detail} "            
+        )
+    )
+);
+
+$message_json = json_encode($message);
+
+// payloadの値としてURLエンコード
+$message_post = "payload=".urlencode($message_json);
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $message_post);
+curl_exec($ch);
+curl_close($ch);
+
+}
 }
 
 echo "メールを送信しました";


### PR DESCRIPTION
## 関連イシュー
#27 

## 検証したこと
①バッチを実行すると処理日がイベントの3日前の場合Slackで通知する
②メッセージの宛先は未回答の人のみ、チャンネルはチームごとに用意するチャンネル
③メッセージにはイベント名、内容、開催日時、回答を促す内容を記載する

- [x] バッチを実行すると処理日がイベントの3日前の場合Slackで通知する
- [x] メッセージの宛先は未回答の人のみ、チャンネルはチームごとに用意するチャンネル
- [x] メッセージにはイベント名、内容、開催日時、回答を促す内容を記載する

## エビデンス
①バッチを実行すると処理日がイベントの3日前の場合Slackで通知する
![image](https://user-images.githubusercontent.com/86884063/189068607-d7d5199d-8496-44c4-ae78-bc7fd3352eea.png)


②メッセージの宛先は未回答の人のみ、チャンネルはチームごとに用意するチャンネル
③メッセージにはイベント名、内容、開催日時、回答を促す内容を記載する

![image](https://user-images.githubusercontent.com/86884063/189068746-69b93328-35bc-406a-b375-f8befd966987.png)

<eventsテーブル>
3日後(2022-09-11)開催予定のイベントは id = event_attendance.event_id = 43 の「料理倶楽部二次会」のみであることを確認

![image](https://user-images.githubusercontent.com/86884063/189072356-e95d5a46-8d5f-4c01-ad08-a8f9b576a5a5.png)


<event_attendanceテーブル>
event_id = 43の status= 1 or 2 のユーザー以外のuser_id = users.id = 1,,4,6 であり、その中でチャンネルにいるのはuser_id = 1のメンバーのみである
つまり、user_id = users.id = 1のユーザーのみがslackでメンションされていれば条件を満たしていることとなる。

![image](https://user-images.githubusercontent.com/86884063/189070383-d15e9b80-c141-47c6-9797-fa57bf8666ce.png)


<usersテーブル>
id = 1 が「かしけん」であり、メンションの情報と一致していることがわかる。

![image](https://user-images.githubusercontent.com/86884063/189070134-acd77613-14a6-477b-876e-4d25d681ee10.png)

